### PR TITLE
hadolint: version bump to 2.4.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,10 +39,41 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Run integration test
+      - name: Run integration test 1
         uses: ./
         with:
           dockerfile: testdata/Dockerfile
+
+      - name: Run integration test 2 - ignore a rule
+        # This step is supposed to print out an info level rule violation
+        # but completely ignore the two rules listed below
+        uses: ./
+        with:
+          dockerfile: testdata/warning.Dockerfile
+          ignore: DL3014 DL3008
+
+      - name: Run integration test 3 - set failure threshold
+        # This step will print out an info level rule violation, but not fail
+        # because of the high failure threshold.
+        uses: ./
+        with:
+          dockerfile: testdata/info.Dockerfile
+          failure-threshold: warning
+
+      - name: Run integration test 4 - output format
+        # This step will never fail, but will print out rule violations as json.
+        uses: ./
+        with:
+          dockerfile: testdata/warning.Dockerfile
+          failure-threshold: error
+          format: json
+
+      - name: Run integration test 4 - output format
+        # This step will never fail, but will print out rule violations.
+        uses: ./
+        with:
+          dockerfile: testdata/warning.Dockerfile
+          config: testdata/hadolint.yaml
 
   release:
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM hadolint/hadolint:v2.1.0-alpine
+FROM hadolint/hadolint:v2.4.0-debian
 
 COPY LICENSE README.md problem-matcher.json /
 COPY hadolint.sh /usr/local/bin/hadolint.sh

--- a/README.md
+++ b/README.md
@@ -15,16 +15,25 @@ Add the following step to your workflow configuration:
 
 ```yml
 steps:
-    - uses: hadolint/hadolint-action@v1.4.0
-      with:
-        dockerfile: Dockerfile
+  - uses: hadolint/hadolint-action@v1.4.0
+    with:
+      dockerfile: Dockerfile
 ```
 
 ## Inputs
 
-| Name       	| Description                             	| Default      	|
-|------------	|-----------------------------------------	|--------------	|
-| dockerfile 	| The path to the Dockerfile to be tested 	| ./Dockerfile 	|
+| Name              | Description                               | Default          |
+|------------------ |------------------------------------------ |----------------- |
+| dockerfile        | The path to the Dockerfile to be tested   | ./Dockerfile     |
+| format            | The output format. One of [tty | json |   | tty              |
+|                   | checkstyle | codeclimate |                |                  |
+|                   | gitlab_codeclimate]                       |                  |
+| ignore            | Space separated list of Hadolint rules to | <none>           |
+|                   | ignore.                                   |                  |
+| config            | Custom path to a Hadolint config file     | ./.hadolint.yaml |
+| failure-threshold | Rule severity threshold for pipeline      | info             |
+|                   | failure. One of [error | warning | info | |                  |
+|                   | style | ignore]                           |                  |
 
 ## Hadolint Configuration
 

--- a/action.yml
+++ b/action.yml
@@ -3,13 +3,42 @@ description: 'Action that runs Hadolint Dockerfile linting tool'
 author: 'Bruno Paz'
 inputs:
   dockerfile:
+    required: false
     description: 'The path to the Dockerfile to lint'
     default: 'Dockerfile'
+  format:
+    required: false
+    description: |
+      The output format, one of [tty (default) | json | checkstyle |
+      codeclimate | gitlab_codeclimate ]
+    default: 'tty'
+  failure-threshold:
+    required: false
+    description: |
+      Fail the pipeline only if rules with severity above this threshold are
+      violated. One of [error | warning | info (default) | style | ignore]
+    default: 'info'
+  ignore:
+    required: false
+    description: 'A space separated string of rules to ignore'
+    default:
+  config:
+    required: false
+    description: 'Path to a config file'
+    default:
+
 runs:
   using: 'docker'
   image: 'Dockerfile'
   args:
+    - -f
+    - ${{ inputs.format }}
+    - -t
+    - ${{ inputs.failure-threshold }}
     - ${{ inputs.dockerfile }}
+  env:
+    HADOLINT_CONFIG: ${{ inputs.config }}
+    HADOLINT_IGNORE: ${{ inputs.ignore }}
 branding:
   icon: 'layers'
   color: 'purple'

--- a/hadolint.sh
+++ b/hadolint.sh
@@ -19,4 +19,13 @@ trap cleanup EXIT
 
 echo "::add-matcher::${TMP_FOLDER}/problem-matcher.json"
 
-hadolint "$@"
+if [ -n "$HADOLINT_CONFIG" ]; then
+  HADOLINT_CONFIG="-c ${HADOLINT_CONFIG}"
+fi
+
+for i in $HADOLINT_IGNORE; do
+  HADOLINT_IGNORE_CMDLINE="${HADOLINT_IGNORE_CMDLINE} --ignore=${i}"
+done
+
+# shellcheck disable=SC2086
+hadolint $HADOLINT_IGNORE_CMDLINE $HADOLINT_CONFIG "$@"

--- a/testdata/hadolint.yaml
+++ b/testdata/hadolint.yaml
@@ -1,0 +1,1 @@
+failure-threshold: error

--- a/testdata/info.Dockerfile
+++ b/testdata/info.Dockerfile
@@ -1,0 +1,5 @@
+FROM debian:buster
+
+# info level warning expected here:
+RUN echo "Hello"
+RUN echo "World"

--- a/testdata/warning.Dockerfile
+++ b/testdata/warning.Dockerfile
@@ -1,0 +1,4 @@
+FROM debian:buster
+
+# emits an info and a warning level violation.
+RUN apt-get install foo


### PR DESCRIPTION
- bump Hadolint version to 2.4.0
- change to debian based image
- add common config options
- expand integration tests for new options

fixes: https://github.com/hadolint/hadolint-action/issues/5
fixes: https://github.com/hadolint/hadolint-action/issues/8
fixes: https://github.com/hadolint/hadolint-action/issues/17
fixes: https://github.com/hadolint/hadolint-action/issues/18
fixes: https://github.com/hadolint/hadolint-action/issues/31