### PR TITLE
build: bump hadolint from v2.4.0 to v2.7.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM hadolint/hadolint:v2.4.0-debian
+FROM hadolint/hadolint:v2.7.0-debian
 
 COPY LICENSE README.md problem-matcher.json /
 COPY hadolint.sh /usr/local/bin/hadolint.sh


### PR DESCRIPTION
It has been more than 3 months since hadolint was updated.

EDIT: @lorenzo Normally @dependabot should open a PR to update hadolint after a new version is released. I wonder why it stopped doing that after #28 in April?