### PR TITLE
features: config options, saving to file, SARIF

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,8 @@ jobs:
         uses: ./
         with:
           dockerfile: testdata/warning.Dockerfile
-          ignore: DL3014 DL3008 DL3015
+          ignore: 'DL3014,DL3008'
+          no-fail: true
 
       - name: Run integration test 3 - set failure threshold
         # This step will print out an info level rule violation, but not fail
@@ -68,12 +69,20 @@ jobs:
           failure-threshold: error
           format: json
 
-      - name: Run integration test 4 - output format
+      - name: Run integration test 5 - output format
         # This step will never fail, but will print out rule violations.
         uses: ./
         with:
           dockerfile: testdata/warning.Dockerfile
           config: testdata/hadolint.yaml
+
+      - name: Run integration test 6 - output to file
+        # This step will never fail, but will print out rule violations.
+        uses: ./
+        with:
+          dockerfile: testdata/warning.Dockerfile
+          format: sarif
+          output-file: /report.sarif
 
   release:
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM hadolint/hadolint:v2.7.0-debian
+FROM hadolint/hadolint:v2.8.0-debian
 
 COPY LICENSE README.md problem-matcher.json /
 COPY hadolint.sh /usr/local/bin/hadolint.sh

--- a/README.md
+++ b/README.md
@@ -23,20 +23,34 @@ steps:
 
 ## Inputs
 
-| Name              | Description                               | Default          |
-|------------------ |------------------------------------------ |----------------- |
-| dockerfile        | The path to the Dockerfile to be tested   | ./Dockerfile     |
-| recursive         | Search for specified dockerfile           | false            | 
-|                   | recursively, from the project root        |                  |
-| format            | The output format. One of [tty \| json \| | tty              |
-|                   | checkstyle \| codeclimate \|              |                  |
-|                   | gitlab_codeclimate]                       |                  |
-| ignore            | Space separated list of Hadolint rules to | <none>           |
-|                   | ignore.                                   |                  |
-| config            | Custom path to a Hadolint config file     | ./.hadolint.yaml |
-| failure-threshold | Rule severity threshold for pipeline      | info             |
-|                   | failure. One of [error \| warning \|      |                  |
-|                   | info \| style \| ignore]                  |                  |
+| Name               | Description                               | Default          |
+|------------------- |------------------------------------------ |----------------- |
+| dockerfile         | The path to the Dockerfile to be tested   | ./Dockerfile     |
+| recursive          | Search for specified dockerfile           | false            |
+|                    | recursively, from the project root        |                  |
+| config             | Custom path to a Hadolint config file     | ./.hadolint.yaml |
+| output-file        | A sub-path where to save the              |                  |
+|                    | output as a file to                       |                  |
+| no-color           | Don't create colored output               |                  |
+| no-fail            | Never fail the action                     |                  |
+| verbose            | Output more information                   |                  |
+| format             | The output format. One of [tty \| json \| | tty              |
+|                    | checkstyle \| codeclimate \|              |                  |
+|                    | gitlab_codeclimate \| codacy \| sarif]    |                  |
+| failure-threshold  | Rule severity threshold for pipeline      | info             |
+|                    | failure. One of [error \| warning \|      |                  |
+|                    | info \| style \| ignore]                  |                  |
+| override-error     | List of rules to treat with 'error'       |                  |
+|                    | severity                                  |                  |
+| override-warning   | List of rules to treat with 'warning'     |                  |
+|                    | severity                                  |                  |
+| override-info      | List of rules to treat with 'info'        |                  |
+|                    | severity                                  |                  |
+| override-style     | List of rules to treat with 'style'       |                  |
+|                    | severity                                  |                  |
+| ignore             | Space separated list of Hadolint rules to | <none>           |
+|                    | ignore.                                   |                  |
+| trusted-resgitries | List of urls of trusted registries        |                  |
 
 ## Hadolint Configuration
 

--- a/action.yml
+++ b/action.yml
@@ -6,15 +6,38 @@ inputs:
     required: false
     description: 'The path to the Dockerfile to lint'
     default: 'Dockerfile'
+  config:
+    required: false
+    description: 'Path to a config file'
+    default:
   recursive:
     required: false
-    description: 'Search for specified dockerfile recursively, from the project root'
+    description:
+      'Search for specified dockerfile recursively, from the project root'
+    default: 'false'
+  output-file:
+    required: false
+    description: 'The path where to save the linting results to'
+    default:
+
+  # standart hadolint options:
+  no-color:
+    required: false
+    description: Don't create colored output.
+    default: 'false'
+  no-fail:
+    required: false
+    description: Never exit with a failure status code
+    default: 'false'
+  verbose:
+    required: false
+    description: Print more information about the running config
     default: 'false'
   format:
     required: false
     description: |
       The output format, one of [tty (default) | json | checkstyle |
-      codeclimate | gitlab_codeclimate ]
+      codeclimate | gitlab_codeclimate | codacy | sarif]
     default: 'tty'
   failure-threshold:
     required: false
@@ -22,28 +45,56 @@ inputs:
       Fail the pipeline only if rules with severity above this threshold are
       violated. One of [error | warning | info (default) | style | ignore]
     default: 'info'
+  override-error:
+    required: false
+    description:
+      'A comma separated list of rules whose severity will be `error`'
+    default:
+  override-warning:
+    required: false
+    description:
+      'A comma separated list of rules whose severity will be `warning`'
+    default:
+  override-info:
+    required: false
+    description:
+      'A comma separated list of rules whose severity will be `info`'
+    default:
+  override-style:
+    required: false
+    description:
+      'A comma separated list of rules whose severity will be `style`'
+    default:
   ignore:
     required: false
-    description: 'A space separated string of rules to ignore'
+    description: 'A comma separated string of rules to ignore'
     default:
-  config:
+  trusted-registries:
     required: false
-    description: 'Path to a config file'
+    description: 'A comma separated list of trusted registry urls'
     default:
 
 runs:
   using: 'docker'
   image: 'Dockerfile'
   args:
-    - -f
-    - ${{ inputs.format }}
-    - -t
-    - ${{ inputs.failure-threshold }}
     - ${{ inputs.dockerfile }}
   env:
-    HADOLINT_CONFIG: ${{ inputs.config }}
+    NO_COLOR: ${{ inputs.no-color }}
+    HADOLINT_NOFAIL: ${{ inputs.no-fail }}
+    HADOLINT_VERBOSE: ${{ inputs.verbose }}
+    HADOLINT_FORMAT: ${{ inputs.format }}
+    HADOLINT_FAILURE_THRESHOLD: ${{ inputs.failure-threshold }}
+    HADOLINT_OVERRIDE_ERROR: ${{ inputs.override-error }}
+    HADOLINT_OVERRIDE_WARNING: ${{ inputs.override-warning }}
+    HADOLINT_OVERRIDE_INFO: ${{ inputs.override-info }}
+    HADOLINT_OVERRIDE_STYLE: ${{ inputs.override-style }}
     HADOLINT_IGNORE: ${{ inputs.ignore }}
+    HADOLINT_TRUSTED_REGISTRIES: ${{ inputs.trusted-registries }}
+
+    HADOLINT_CONFIG: ${{ inputs.config }}
     HADOLINT_RECURSIVE: ${{ inputs.recursive }}
+    HADOLINT_OUTPUT: ${{ inputs.output-file }}
 branding:
   icon: 'layers'
   color: 'purple'

--- a/hadolint.sh
+++ b/hadolint.sh
@@ -23,9 +23,13 @@ if [ -n "$HADOLINT_CONFIG" ]; then
   HADOLINT_CONFIG="-c ${HADOLINT_CONFIG}"
 fi
 
-for i in $HADOLINT_IGNORE; do
-  HADOLINT_IGNORE_CMDLINE="${HADOLINT_IGNORE_CMDLINE} --ignore=${i}"
-done
+OUTPUT=
+if [ -n "$HADOLINT_OUTPUT" ]; then
+  if [ -f "$HADOLINT_OUTPUT" ]; then
+    HADOLINT_OUTPUT="$TMP_FOLDER/$HADOLINT_OUTPUT"
+  fi
+  OUTPUT=" | tee $HADOLINT_OUTPUT"
+fi
 
 if [ "$HADOLINT_RECURSIVE" = "true" ]; then
   shopt -s globstar
@@ -33,8 +37,10 @@ if [ "$HADOLINT_RECURSIVE" = "true" ]; then
   filename="${!#}"
   flags="${@:1:$#-1}"
 
-  hadolint $HADOLINT_IGNORE_CMDLINE $HADOLINT_CONFIG $flags **/$filename
+  hadolint $HADOLINT_CONFIG $flags **/$filename $OUTPUT
 else
   # shellcheck disable=SC2086
-  hadolint $HADOLINT_IGNORE_CMDLINE $HADOLINT_CONFIG "$@"
+  hadolint $HADOLINT_CONFIG "$@" $OUTPUT
 fi
+
+[ -z "$HADOLINT_OUTPUT" ] || echo "Hadolint output saved to: $HADOLINT_OUTPUT"


### PR DESCRIPTION
- Upgrade to Hadolint 2.8.0, enabling the SARIF formatter
- Expand config options to reflect more of those regularly available
  with Hadolint including `no-fail` and `failure-threshold` options
- Enable the creation of report files

**Breaking change**: The list of ignored rules is now comma separated and
not space separated.

fixes: #23
fixes: #36
fixes: #42