### PR TITLE
fix: missing problem-matcher

### DIFF
--- a/hadolint.sh
+++ b/hadolint.sh
@@ -1,23 +1,19 @@
 #!/bin/bash
 
 # The problem-matcher definition must be present in the repository
-# checkout (outside the Docker container running hadolint). We create
-# a temporary folder and copy problem-matcher.json to it and make it
-# readable.
-TMP_FOLDER=$(mktemp -d -p .)
-cp /problem-matcher.json "${TMP_FOLDER}"
-chmod -R a+rX "${TMP_FOLDER}"
+# checkout (outside the Docker container running hadolint). We copy
+# problem-matcher.json to the home folder.
+cp /problem-matcher.json "$HOME/"
 
 # After the run has finished we remove the problem-matcher.json from
 # the repository so we don't leave the checkout dirty. We also remove
 # the matcher so it won't take effect in later steps.
 cleanup() {
     echo "::remove-matcher owner=brpaz/hadolint-action::"
-    rm -rf "${TMP_FOLDER}"
 }
 trap cleanup EXIT
 
-echo "::add-matcher::${TMP_FOLDER}/problem-matcher.json"
+echo "::add-matcher::$HOME/problem-matcher.json"
 
 if [ -n "$HADOLINT_CONFIG" ]; then
   HADOLINT_CONFIG="-c ${HADOLINT_CONFIG}"


### PR DESCRIPTION
## Rationale

Attempt to address #44 by changing the matcher directory.
It uses the solution mentioned in https://github.com/actions/toolkit/issues/305#issuecomment-585515210.

Instead of uploading the file in the workdir (which is a mounted volume), it uses `$HOME`.