### PR TITLE
Apply exit code to hadolint.sh

### DIFF
--- a/hadolint.sh
+++ b/hadolint.sh
@@ -27,16 +27,19 @@ if [ -n "$HADOLINT_OUTPUT" ]; then
   OUTPUT=" | tee $HADOLINT_OUTPUT"
 fi
 
+FAILED=0
 if [ "$HADOLINT_RECURSIVE" = "true" ]; then
   shopt -s globstar
 
   filename="${!#}"
   flags="${@:1:$#-1}"
 
-  hadolint $HADOLINT_CONFIG $flags **/$filename $OUTPUT
+  hadolint $HADOLINT_CONFIG $flags **/$filename $OUTPUT || FAILED=1
 else
   # shellcheck disable=SC2086
-  hadolint $HADOLINT_CONFIG "$@" $OUTPUT
+  hadolint $HADOLINT_CONFIG "$@" $OUTPUT || FAILED=1
 fi
 
 [ -z "$HADOLINT_OUTPUT" ] || echo "Hadolint output saved to: $HADOLINT_OUTPUT"
+
+exit $FAILED


### PR DESCRIPTION
Exiting with an exit code of 1 marks the job in github actions as a fail properly. This should help to fix #48. I have noticed that you need to explicitly add docker.io to the trusted registries when running the github action. I updated the testing action to run with the following configuration:

```yml
steps:
  - uses: actions/checkout@v2 
  - uses: hadolint/hadolint-action@v1.6.0
    with:
      dockerfile: Dockerfile
      trusted-registries: "docker.io"
```