### PR TITLE
docs: correctly identify comma-separated list for ignore param

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ steps:
 |                    | severity                                  |                  |
 | override-style     | List of rules to treat with 'style'       |                  |
 |                    | severity                                  |                  |
-| ignore             | Space separated list of Hadolint rules to | <none>           |
+| ignore             | Comma-separated list of Hadolint rules to | <none>           |
 |                    | ignore.                                   |                  |
 | trusted-registries | List of urls of trusted registries        |                  |
 


### PR DESCRIPTION
v1.7.0 changed the `ignore` parameter from a space-separated list to a comma-separated list. Only noticed now because v2.0 fails from the errors.

I see the action description was updated - https://github.com/hadolint/hadolint-action/compare/v1.6.0...v1.7.0#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6R70 but the README still says to use a space-separated list, which is what tricked me - https://github.com/hadolint/hadolint-action/compare/v1.6.0...v1.7.0#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R51 .

Updating the README to reflect this change.