### PR TITLE
feat: expose results of hadolint to env var

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,26 @@ jobs:
         # This step will never fail, but will print out the results from step5
         run: echo "${{ steps.hadolint5.outputs.results }}"
 
+      - name: Update Pull Request
+        uses: actions/github-script@v6
+        if: github.event_name == 'pull_request'
+        with:
+          script: |
+            const output = `
+            #### Hadolint: \`${{ steps.hadolint.outcome }}\`
+            _output from integration test 5_
+            \`\`\`
+            ${{ steps.hadolint5.outputs.results }}
+            \`\`\`
+            `;
+
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: output
+            })
+
       #- name: Run integration test 6 - output to file
       #  # This step will never fail, but will print out rule violations.
       #  uses: ./

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
 
       - name: Run integration test 6 - verify results output parameter
         # This step will never fail, but will print out the results from step5
-        run: echo ${{ steps.hadolint5.outputs.results }}
+        run: echo "${{ steps.hadolint5.outputs.results }}"
 
       #- name: Run integration test 6 - output to file
       #  # This step will never fail, but will print out rule violations.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
 
       - name: Run integration test 6 - verify results output parameter
         # This step will never fail, but will print out the results from step5
-        run: echo {{ steps.hadolint5.outputs.results }}
+        run: echo ${{ steps.hadolint5.outputs.results }}
 
       #- name: Run integration test 6 - output to file
       #  # This step will never fail, but will print out rule violations.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,26 +81,6 @@ jobs:
         # This step will never fail, but will print out the results from step5
         run: echo "${{ steps.hadolint5.outputs.results }}"
 
-      - name: Update Pull Request
-        uses: actions/github-script@v6
-        if: github.event_name == 'pull_request'
-        with:
-          script: |
-            const output = `
-            #### Hadolint: \`${{ steps.hadolint5.outcome }}\`
-            _output from integration test 5_
-            \`\`\`
-            ${process.env.HADOLINT_RESULTS}
-            \`\`\`
-            `;
-
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: output
-            })
-
       #- name: Run integration test 6 - output to file
       #  # This step will never fail, but will print out rule violations.
       #  uses: ./

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
             #### Hadolint: \`${{ steps.hadolint.outcome }}\`
             _output from integration test 5_
             \`\`\`
-            ${{ steps.hadolint5.outputs.results }}
+            ${process.env.HADOLINT_RESULTS}
             \`\`\`
             `;
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,10 +71,15 @@ jobs:
 
       - name: Run integration test 5 - output format
         # This step will never fail, but will print out rule violations.
+        id: hadolint5
         uses: ./
         with:
           dockerfile: testdata/warning.Dockerfile
           config: testdata/hadolint.yaml
+
+      - name: Run integration test 6 - verify results output parameter
+        # This step will never fail, but will print out the results from step5
+        run: echo {{ steps.hadolint5.outputs.results }}
 
       #- name: Run integration test 6 - output to file
       #  # This step will never fail, but will print out rule violations.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
         with:
           script: |
             const output = `
-            #### Hadolint: \`${{ steps.hadolint.outcome }}\`
+            #### Hadolint: \`${{ steps.hadolint5.outcome }}\`
             _output from integration test 5_
             \`\`\`
             ${process.env.HADOLINT_RESULTS}

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 
 IMAGE_NAME:=hadolint-action
 
-lint-dockerfile: ## Runs hadoint against application dockerfile
+lint-dockerfile: ## Runs hadolint against application dockerfile
 	@docker run --rm -v "$(PWD):/data" -w "/data" hadolint/hadolint hadolint Dockerfile
 
 lint-yaml: ## Lints yaml configurations
@@ -12,8 +12,8 @@ build: ## Builds the docker image
 
 test: build ## Runs a test in the image
 	@docker run -i --rm \
-  -v /var/run/docker.sock:/var/run/docker.sock \
-  -v ${PWD}:/test zemanlx/container-structure-test:v1.8.0-alpine \
+    -v /var/run/docker.sock:/var/run/docker.sock \
+    -v ${PWD}:/test zemanlx/container-structure-test:v1.8.0-alpine \
     test \
     --image $(IMAGE_NAME) \
     --config test/structure-tests.yaml

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Example to create a comment in a PR:
   with:
     script: |
       const output = `
-      #### Hadolint: \`${{ steps.hadolint5.outcome }}\`
+      #### Hadolint: \`${{ steps.hadolint.outcome }}\`
       \`\`\`
       ${process.env.HADOLINT_RESULTS}
       \`\`\`

--- a/README.md
+++ b/README.md
@@ -40,6 +40,33 @@ steps:
 | `ignore`             | Comma separated list of Hadolint rules to ignore.                                                                                       | <none>             |
 | `trusted-registries` | Comma separated list of urls of trusted registries                                                                                      |                    |
 
+## Output
+
+The Action will store results in an environment variable that can be used in other steps in a workflow.
+
+Example to create a comment in a PR:
+
+```
+- name: Update Pull Request
+  uses: actions/github-script@v6
+  if: github.event_name == 'pull_request'
+  with:
+    script: |
+      const output = `
+      #### Hadolint: \`${{ steps.hadolint5.outcome }}\`
+      \`\`\`
+      ${process.env.HADOLINT_RESULTS}
+      \`\`\`
+      `;
+
+      github.rest.issues.createComment({
+        issue_number: context.issue.number,
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        body: output
+      })
+```
+
 ## Hadolint Configuration
 
 To configure Hadolint (for example ignore rules), you can create an `.hadolint.yaml` file in the root of your repository. Please check the Hadolint [documentation](https://github.com/hadolint/hadolint#configure).

--- a/hadolint.sh
+++ b/hadolint.sh
@@ -43,7 +43,7 @@ if [ -n "$HADOLINT_OUTPUT" ]; then
   echo "$RESULTS" > $HADOLINT_OUTPUT
 fi
 
-RESULTS="${RESULTS//\`/\\\`}"
+RESULTS="${RESULTS//$'\\n'/''}"
 echo "::set-output name=results::$RESULTS"
 
 [ -z "$HADOLINT_OUTPUT" ] || echo "Hadolint output saved to: $HADOLINT_OUTPUT"

--- a/hadolint.sh
+++ b/hadolint.sh
@@ -46,6 +46,8 @@ fi
 RESULTS="${RESULTS//$'\\n'/''}"
 echo "::set-output name=results::$RESULTS"
 
+{ echo "HADOLINT_RESULTS<<EOF"; echo "$RESULTS"; echo "EOF"; } >> $GITHUB_ENV
+
 [ -z "$HADOLINT_OUTPUT" ] || echo "Hadolint output saved to: $HADOLINT_OUTPUT"
 
 exit $FAILED

--- a/hadolint.sh
+++ b/hadolint.sh
@@ -36,14 +36,15 @@ else
 fi
 FAILED=$?
 
-echo "::set-output name=results::$RESULTS"
-
 if [ -n "$HADOLINT_OUTPUT" ]; then
   if [ -f "$HADOLINT_OUTPUT" ]; then
     HADOLINT_OUTPUT="$TMP_FOLDER/$HADOLINT_OUTPUT"
   fi
   echo "$RESULTS" > $HADOLINT_OUTPUT
 fi
+
+RESULTS="${RESULTS//\`/\\\`}"
+echo "::set-output name=results::$RESULTS"
 
 [ -z "$HADOLINT_OUTPUT" ] || echo "Hadolint output saved to: $HADOLINT_OUTPUT"
 

--- a/hadolint.sh
+++ b/hadolint.sh
@@ -23,25 +23,26 @@ if [ -z "$HADOLINT_TRUSTED_REGISTRIES" ]; then
   unset HADOLINT_TRUSTED_REGISTRIES;
 fi
 
-OUTPUT=
-if [ -n "$HADOLINT_OUTPUT" ]; then
-  if [ -f "$HADOLINT_OUTPUT" ]; then
-    HADOLINT_OUTPUT="$TMP_FOLDER/$HADOLINT_OUTPUT"
-  fi
-  OUTPUT=" | tee $HADOLINT_OUTPUT"
-fi
-
-FAILED=0
 if [ "$HADOLINT_RECURSIVE" = "true" ]; then
   shopt -s globstar
 
   filename="${!#}"
   flags="${@:1:$#-1}"
 
-  hadolint $HADOLINT_CONFIG $flags **/$filename $OUTPUT || FAILED=1
+  RESULTS=$(hadolint $HADOLINT_CONFIG $flags **/$filename)
 else
   # shellcheck disable=SC2086
-  hadolint $HADOLINT_CONFIG "$@" $OUTPUT || FAILED=1
+  RESULTS=$(hadolint $HADOLINT_CONFIG "$@")
+fi
+FAILED=$?
+
+echo "::set-output name=results::$RESULTS"
+
+if [ -n "$HADOLINT_OUTPUT" ]; then
+  if [ -f "$HADOLINT_OUTPUT" ]; then
+    HADOLINT_OUTPUT="$TMP_FOLDER/$HADOLINT_OUTPUT"
+  fi
+  echo "$RESULTS" > $HADOLINT_OUTPUT
 fi
 
 [ -z "$HADOLINT_OUTPUT" ] || echo "Hadolint output saved to: $HADOLINT_OUTPUT"


### PR DESCRIPTION
This pushes all results from hadolint into both a var named results and an environment variable for easy pickup in other steps in a workflow.

There's a single integration-test included that makes use of this feature, pushing the result back into a pending PR.

Additionally, I found the `tee` trick to be broken as hadolint mistakenly wanted to parse/use the `| tee outputfile.txt` as input. Hence writing to file is now done using a plain echo.