### PR TITLE
Update hadolint to 2.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM hadolint/hadolint:v2.9.3-debian
+FROM ghcr.io/hadolint/hadolint:v2.10.0-debian
 
 COPY LICENSE README.md problem-matcher.json /
 COPY hadolint.sh /usr/local/bin/hadolint.sh


### PR DESCRIPTION
Updates to latest hadolint v2.10.

Since there are up-to-date images available through GHCR (but not on Dockerhub), I have switched the `FROM` accordingly.