### PR TITLE
Fix Configuration File and 'problem-matcher' Pathing Issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM ghcr.io/hadolint/hadolint:v2.10.0-debian
 
+# Set default WORKDIR in Dockerfile for easier trace and consistency
+WORKDIR /github/workspace
+
 COPY LICENSE README.md problem-matcher.json /
 COPY hadolint.sh /usr/local/bin/hadolint.sh
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ steps:
 |----------------------|-----------------------------------------------------------------------------------------------------------------------------------------|--------------------|
 | `dockerfile`         | The path to the Dockerfile to be tested                                                                                                 | `./Dockerfile`     |
 | `recursive`          | Search for specified dockerfile </br> recursively, from the project root                                                                | `false`            |
-| `config`             | Custom path to a Hadolint config file                                                                                                   | `./.hadolint.yaml` |
+| `config`             | Custom path to a Hadolint config file                                                                                                   |                    |
 | `output-file`        | A sub-path where to save the </br> output as a file to                                                                                  |                    |
 | `no-color`           | Don't create colored output (`true`/`false`)                                                                                            |                    |
 | `no-fail`            | Never fail the action (`true`/`false`)                                                                                                  |                    |

--- a/hadolint.sh
+++ b/hadolint.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Set essential environment variables in the container
+export {PWD,HOME}=$(pwd)
+
 # The problem-matcher definition must be present in the repository
 # checkout (outside the Docker container running hadolint). We copy
 # problem-matcher.json to the home folder.
@@ -16,7 +19,7 @@ trap cleanup EXIT
 echo "::add-matcher::$HOME/problem-matcher.json"
 
 if [ -n "$HADOLINT_CONFIG" ]; then
-  HADOLINT_CONFIG="-c ${HADOLINT_CONFIG}"
+  HADOLINT_CONFIG="-c ${PWD}/${HADOLINT_CONFIG}"
 fi
 
 if [ -z "$HADOLINT_TRUSTED_REGISTRIES" ]; then


### PR DESCRIPTION
Please refer to #58 for details of the issue(s).

### SOLUTIONS
- Forked to test out the following fix in `Dockerfile`:
```
# Set essential environment variables in the container
ENV HOME /github/workspace
ENV PWD /github/workspace

# Set default WORKDIR in Dockerfile for easier trace and consistency
WORKDIR /github/workspace
```
It seems a bit crude to hardcode, it would lock-in that variable.  However, I noticed the repository relies on GitHub environment; this would be just a-okay :D
- OR set the environment variables in `hadolint.sh` for more dynamic approach:
```
# Set essential environment variables in the container
export {PWD,HOME}=$(pwd)
```
- Prepending `inputs.config` with a little bit of editing:
```
HADOLINT_CONFIG="-c ${PWD}/${HADOLINT_CONFIG}"
```

1. Not supplying `inputs.config` with `.hadolint.yaml` present works now!  (it defaults back to `hadolint` configuration file places _INVESTIGATION.0_)
```
- uses: kgrv-me/hadolint-action@fix/PathingIssue
```

2. Supply `hadolint.yaml` to `inputs.config` also works!  (`hadolint` won't pick up `hadolint.yaml` by default)
```
- uses: kgrv-me/hadolint-action@fix/PathingIssue
  with:
    config: hadolint.yaml
```


### EXTRA ISSUE NOTED
`/github/workspace` seems intended to be default `HOME` in `hadolint.sh` for `problem-matcher.json`.
However, `problem-matcher.json` never made it ouside the container into the repository as intended due to `HOME=/root` (_INVESTIGATION.6_)

```
Fixing this ticket (pathing issue) via the above methods
would resolve `problem-matcher.json` condition as well!
```

Cheers!