### PR TITLE
Use env to avoid script injection in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,8 +78,10 @@ jobs:
           config: testdata/hadolint.yaml
 
       - name: Run integration test 6 - verify results output parameter
+        env:
+          STEP_5_OUTPUT: ${{ steps.hadolint5.outputs.results }}
         # This step will never fail, but will print out the results from step5
-        run: echo "${{ steps.hadolint5.outputs.results }}"
+        run: echo "$STEP_5_OUTPUT"
 
       #- name: Run integration test 6 - output to file
       #  # This step will never fail, but will print out rule violations.


### PR DESCRIPTION
I haven't tested this, and I'm not sure if the output can contain anything usable in an exploit, but using env variables for untrusted input is recommended in general:

https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#example-of-a-script-injection-attack