### PR TITLE
fix: update deprecated commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-20.04
     container: pipelinecomponents/hadolint:0.10.1
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Run hadolint
         run: hadolint Dockerfile
 
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-20.04
     needs: ["lint"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Build Docker image
         run: docker build -t $TEST_IMAGE_NAME .
 
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-20.04
     needs: build-test
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Run integration test 1
         uses: ./

--- a/hadolint.sh
+++ b/hadolint.sh
@@ -44,7 +44,10 @@ if [ -n "$HADOLINT_OUTPUT" ]; then
 fi
 
 RESULTS="${RESULTS//$'\\n'/''}"
-echo "::set-output name=results::$RESULTS"
+
+echo "results<<EOF" >> $GITHUB_OUTPUT
+echo "${RESULTS}" >> $GITHUB_OUTPUT
+echo "EOF" >> $GITHUB_OUTPUT
 
 { echo "HADOLINT_RESULTS<<EOF"; echo "$RESULTS"; echo "EOF"; } >> $GITHUB_ENV
 


### PR DESCRIPTION
Fix issue #63 

updated

Update deprecated set-output to use the new format for multi-line strings as described in the GitHub documentation:

(https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings)

Also updated actions/checkout to the non-deprecated v3.

@austinpray-mixpanel Needed to update this for multi-line string handling, can you review please, thanks
