### PR TITLE
Upgrade hadolint to 2.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/hadolint/hadolint:v2.10.0-debian
+FROM ghcr.io/hadolint/hadolint:v2.11.0-debian
 
 COPY LICENSE README.md problem-matcher.json /
 COPY hadolint.sh /usr/local/bin/hadolint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/hadolint/hadolint:v2.11.0-debian
+FROM ghcr.io/hadolint/hadolint:v2.12.0-debian
 
 COPY LICENSE README.md problem-matcher.json /
 COPY hadolint.sh /usr/local/bin/hadolint.sh


### PR DESCRIPTION
Upgrade hadolint to 2.11 to support copying from images, not only stages and other [improvements](https://github.com/hadolint/hadolint/releases/tag/v2.11.0).
I didn't upgrade to 2.12 as it doesn't add any features. Let me know if you think it is worth upgrading to the latest.

**Update**
Upgrade to hadolint 2.12
