### PR TITLE
Fix the url to the build badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@
 [![License](https://img.shields.io/badge/License-MIT-yellow.svg?style=for-the-badge)](LICENSE)
 [![Commitizen friendly](https://img.shields.io/badge/commitizen-friendly-brightgreen.svg?style=for-the-badge)](http://commitizen.github.io/cz-cli/)
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg?style=for-the-badge)](https://github.com/semantic-release/semantic-release?style=for-the-badge)
-[![GitHub Workflow Status](https://img.shields.io/github/workflow/status/hadolint/hadolint-action/CI?style=for-the-badge)](https://github.com/hadolint/hadolint-action/action)
+[![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/hadolint/hadolint-action/ci.yml?branch=master&style=for-the-badge)](https://github.com/hadolint/hadolint-action/action)
+
 
 ## Usage
 


### PR DESCRIPTION
As suggested in https://github.com/badges/shields/issues/8671

it said:

> You need to update your badge URL from
> https://img.shields.io/github/workflow/status/<user>/<repo>/Run%20Tests
> to
> https://img.shields.io/github/actions/workflow/status/<user>/<repo>/test.yml?branch=main
