### PR TITLE
Make output-file by default to /dev/stdout

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ inputs:
   output-file:
     required: false
     description: 'The path where to save the linting results to'
-    default:
+    default: "/dev/stdout"
 
   # standart hadolint options:
   no-color:


### PR DESCRIPTION
To fix https://github.com/hadolint/hadolint-action/issues/60 in hadolint-action>v2.0.0