### PR TITLE
Adds support for multiple dockerfile targets

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,7 @@ author: 'Bruno Paz'
 inputs:
   dockerfile:
     required: false
-    description: 'The path to the Dockerfile to lint'
+    description: 'Path to Dockerfile(s). Provide a single path or multiple paths space-separated (e.g., "Dockerfile path/to/another/Dockerfile").'
     default: 'Dockerfile'
   format:
     required: false

--- a/hadolint.sh
+++ b/hadolint.sh
@@ -12,8 +12,8 @@ chmod -R a+rX "${TMP_FOLDER}"
 # the repository so we don't leave the checkout dirty. We also remove
 # the matcher so it won't take effect in later steps.
 cleanup() {
-    echo "::remove-matcher owner=brpaz/hadolint-action::"
-    rm -rf "${TMP_FOLDER}"
+  echo "::remove-matcher owner=brpaz/hadolint-action::"
+  rm -rf "${TMP_FOLDER}"
 }
 trap cleanup EXIT
 
@@ -27,5 +27,7 @@ for i in $HADOLINT_IGNORE; do
   HADOLINT_IGNORE_CMDLINE="${HADOLINT_IGNORE_CMDLINE} --ignore=${i}"
 done
 
+DOCKERFILE_LIST=$(printf '%s ' "$@")
+
 # shellcheck disable=SC2086
-hadolint $HADOLINT_IGNORE_CMDLINE $HADOLINT_CONFIG "$@"
+hadolint $HADOLINT_IGNORE_CMDLINE $HADOLINT_CONFIG $DOCKERFILE_LIST


### PR DESCRIPTION
Introduces a non-breaking change to permit multiple dockerfiles to be passed as a space-delimited string. I'm using it like this to lint multiple entries per repo:

```yaml
      - name: Find (Docker|Container)file
        uses: jeertmans/filesfinder@latest
        id: ff
        with:
          args: -d ${{ matrix.target }} --no-strip-prefix -r "/([Dd]ocker|[Cc]ontainer)[Ff]ile$"
      - name: Print files
        run: echo "${{ steps.ff.outputs.files }}"
      - name: 🚀 Run Hadolint
        uses: dcode/hadolint-action@master
        with:
          dockerfile: "${{ steps.ff.outputs.files }}"
```

I just noticed that my editor auto-formatted the script. If that's problematic, I can redo the commit without those lines.