### PR TITLE
Update hadolint to v2.13.1-beta2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/hadolint/hadolint:v2.12.0-debian
+FROM ghcr.io/hadolint/hadolint:v2.13.1-beta2-debian
 
 COPY LICENSE README.md problem-matcher.json /
 COPY hadolint.sh /usr/local/bin/hadolint.sh


### PR DESCRIPTION
This is not to be merged, it's just to allow people who need it to use it with:

```yaml
- uses: hadolint/hadolint-action@refs/pull/<>/merge
```