### PR TITLE
docs: update actions/checkout to v4 in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Add the following step to your workflow configuration:
 
 ```yml
 steps:
-  - uses: actions/checkout@v3
+  - uses: actions/checkout@v4
   - uses: hadolint/hadolint-action@v3.1.0
     with:
       dockerfile: Dockerfile


### PR DESCRIPTION
GitHub recommends using `actions/checkout@v4`, which runs on Node 20.

This PR updates the README usage example from `checkout@v3` to `checkout@v4`.

No functional changes.