### PR TITLE
Pin hadolint base image by digest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/hadolint/hadolint:v2.14.0-debian
+FROM ghcr.io/hadolint/hadolint:v2.14.0-debian@sha256:158cd0184dcaa18bd8ec20b61f4c1cabdf8b32a592d062f57bdcb8e4c1d312e2
 
 COPY LICENSE README.md problem-matcher.json /
 COPY hadolint.sh /usr/local/bin/hadolint.sh


### PR DESCRIPTION
## Summary

Pin the `ghcr.io/hadolint/hadolint:v2.14.0-debian` base image to its immutable OCI digest in the action Dockerfile.

## Why

The action currently references the hadolint image by tag only:

```Dockerfile
FROM ghcr.io/hadolint/hadolint:v2.14.0-debian
```

While the version tag improves readability, it does not fully guarantee immutability on its own. Pinning the image by digest makes the exact image content explicit and helps reduce supply-chain risk from an unexpected tag retargeting or registry-side image replacement.

This keeps the human-readable version tag while ensuring builds resolve to the expected image:

```Dockerfile
FROM ghcr.io/hadolint/hadolint:v2.14.0-debian@sha256:158cd0184dcaa18bd8ec20b61f4c1cabdf8b32a592d062f57bdcb8e4c1d312e2
```

## Change

- Pin the hadolint base image in `Dockerfile` with the published digest for `v2.14.0-debian`

## Notes

- This uses the multi-arch OCI index digest for `ghcr.io/hadolint/hadolint:v2.14.0-debian`
- No behavioral change is intended beyond making the base image reference immutable
