### PR TITLE
CI: run integration tests with different runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,9 +56,15 @@ jobs:
 
   integration-tests:
     name: Integration Tests
-    runs-on: ubuntu-24.04
     needs:
       - build-test
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - ubuntu-24.04
+          - ubuntu-24.04-arm
+
     steps:
       - uses: actions/checkout@v5
 


### PR DESCRIPTION
Run integration tests with different runner variants to make sure that The Hadolint action works across different GitHub Actions platforms.

related-to: hadolint/hadolint-action#100